### PR TITLE
[C++] Add currentChunkStart() / currentChunkEnd() to McapWriter (#1)

### DIFF
--- a/cpp/mcap/include/mcap/writer.hpp
+++ b/cpp/mcap/include/mcap/writer.hpp
@@ -395,6 +395,18 @@ public:
   Status write(const Metadata& metadata);
 
   /**
+   * @brief Returns the timestamp of the earliest message in the current chunk,
+   * or MaxTime if no chunk is in progress.
+   */
+  Timestamp currentChunkStart() const;
+
+  /**
+   * @brief Returns the timestamp of the latest message in the current chunk, or
+   * zero if no chunk is in progress.
+   */
+  Timestamp currentChunkEnd() const;
+
+  /**
    * @brief Current MCAP file-level statistics. This is written as a Statistics
    * record in the Summary section of the MCAP file.
    */

--- a/cpp/mcap/include/mcap/writer.inl
+++ b/cpp/mcap/include/mcap/writer.inl
@@ -653,6 +653,14 @@ Status McapWriter::write(const Metadata& metadata) {
   return StatusCode::Success;
 }
 
+Timestamp McapWriter::currentChunkStart() const {
+  return currentChunkStart_;
+}
+
+Timestamp McapWriter::currentChunkEnd() const {
+  return currentChunkEnd_;
+}
+
 const Statistics& McapWriter::statistics() const {
   return statistics_;
 }


### PR DESCRIPTION
### Changelog
Adds two getter methods to the C++ `McapWriter` class to expose the in-progress chunk's start/end timestamps.

### Docs

None

### Description

The C++ McapWriter class currently supports one built-in rule for automatic chunking which is based on the sum of uncompressed message size. In addition to (or in lieu of) this rule, it is often useful to split chunks based on a fixed timing cadence such as every N seconds. This PR exposes `McapWriter::currentChunkStart()` and `McapWriter::currentChunkEnd()` which can be used for that calculation.