### PR TITLE
c++: Fix implicit int to uint16_t conversion in ParseUint16()

### DIFF
--- a/cpp/mcap/include/mcap/internal.hpp
+++ b/cpp/mcap/include/mcap/internal.hpp
@@ -69,7 +69,7 @@ inline const std::string CompressionString(Compression compression) {
 }
 
 inline uint16_t ParseUint16(const std::byte* data) {
-  return uint16_t(data[0]) | (uint16_t(data[1]) << 8);
+  return uint16_t(data[0] | (data[1] << 8));
 }
 
 inline uint32_t ParseUint32(const std::byte* data) {


### PR DESCRIPTION
Fixes a compiler warning